### PR TITLE
Request a RetroGuard release v3.6.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'fatjar'
 apply plugin: 'maven'
 
 group = 'de.oceanlabs.mcp'
-version = '3.6.6-SNAPSHOT'
+version = '3.6.6'
 targetCompatibility = '1.6'
 sourceCompatibility = '1.6'
 


### PR DESCRIPTION
Because Retroguard packages the Signature ASM classes, ASM has been crashing with a MethodNotFOundException. In recent commits to Retroguard, these packaged classes have been shadowed in a way where they will no longer cause a problem with SpecialSource.

For that reason, I reuquest that this PR is pulled in order to signal to jenkins that this should be uploaded as a new version rather than a snapshot. Then the vesion will be accessible to me in ForgeGradle.
